### PR TITLE
Implemented proper error messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
 - Added support for polygon chain
 
 
-### 1.1.0 (2022-09-28)
+### 1.1.1 (2022-09-28)
 
 - Updated method to get list of supported tokens
+
+### 1.1.2 (2022-12-14)
+
+- Functions `approvalRawTransaction()` and `getRawTransaction()` will throw an error `Insufficient balance.` if the `from` address does not have enough assets to swap.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/uniswap-controller",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Uniswap controller for safle token swaps",
   "main": "src/index.js",
   "scripts": {

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -205,11 +205,11 @@ const setErrorResponse = (err) => {
         case INVARIANT_ADDRESS:
         case QUOTE_OF_NULL:
         case NULL_ROUTE:
-            return { err, message: TOKEN_PAIR_DOESNOT_EXIST }
+            throw TOKEN_PAIR_DOESNOT_EXIST
         case INSUFFICIENT_BALANCE:
-            return { err, message: INSUFFICIENT_BALANCE }
+            throw INSUFFICIENT_BALANCE
         default:
-            return { err, message: err.message }
+            throw err.message
     }
 }
 


### PR DESCRIPTION
Functions `approvalRawTransaction()` and `getRawTransaction()` will throw an error `Insufficient balance.` if the `from` address does not have enough assets to swap.